### PR TITLE
Remove duplicate predicates

### DIFF
--- a/lib/rdf_digest.rb
+++ b/lib/rdf_digest.rb
@@ -15,6 +15,10 @@ module RDF::Digest
   # Höfig/Schieferdecker in "Hashing of RDF Graphs and a Solution to the Blank Node Problem".
   # http://ceur-ws.org/Vol-1259
   def self.hash(graph)
+    ::Digest::SHA256.hexdigest(get_graph_string(graph))
+  end
+
+  def self.get_graph_string(graph)
     subject_strings = []
     graph.subjects(unique: true).each do |subject|
       visited_nodes = []
@@ -29,7 +33,7 @@ module RDF::Digest
       converter = Encoding::Converter.new(string_data.encoding, "UTF-8")
       string_data = converter.convert(string_data)
     end
-    ::Digest::SHA256.hexdigest(string_data)
+    string_data
   end
 
   def self.encode_subject(subject, visited_nodes, graph)
@@ -46,7 +50,7 @@ module RDF::Digest
   end
 
   def self.encode_properties(subject, visited_nodes, graph)
-    predicates = predicates(subject, graph).sort
+    predicates = predicates(subject, graph).sort.uniq
     result = String.new
     predicates.each do |predicate|
       result << A_P << predicate

--- a/spec/data/supersimple.ttl
+++ b/spec/data/supersimple.ttl
@@ -1,0 +1,11 @@
+@prefix ex: <http://ex#> .
+
+_:01 ex:pred ex:C ;
+   ex:pred [
+   ex:pred ex:A ;
+   ex:pred ex:C ] .
+
+_:02 ex:pred ex:C ;
+   ex:pred [
+   ex:pred ex:B ;
+   ex:pred ex:C ] .

--- a/spec/data/supersimple.txt
+++ b/spec/data/supersimple.txt
@@ -1,0 +1,1 @@
+{*(http://ex#pred[*(http://ex#pred[http://ex#A][http://ex#C])][http://ex#C])}{*(http://ex#pred[*(http://ex#pred[http://ex#B][http://ex#C])][http://ex#C])}{*(http://ex#pred[http://ex#A][http://ex#C])}{*(http://ex#pred[http://ex#B][http://ex#C])}

--- a/spec/rdf_digest_spec.rb
+++ b/spec/rdf_digest_spec.rb
@@ -3,6 +3,8 @@ require File.join(File.dirname(__FILE__), 'spec_helper')
 describe RDF::Digest do
   let(:nt) { RDF::Graph.load(fixture_path('doap.nt')) }
   let(:ttl) { RDF::Graph.load(fixture_path('doap.ttl'), format:  :ttl) }
+  let(:simplettl) { RDF::Graph.load(fixture_path('supersimple.ttl'), format: :ttl) }
+  let(:simpletxt) { File.read(fixture_path('supersimple.txt')) }
 
   it "runs at all" do
     nt_hash = described_class.hash(nt)
@@ -11,5 +13,10 @@ describe RDF::Digest do
     ttl_hash = described_class.hash(ttl)
     puts "ttl_hash: #{ttl_hash}"
     expect(nt_hash).to eql ttl_hash
+    simple_string = described_class.get_graph_string(simplettl)
+    puts "simple_string: #{simple_string}"
+    expect(simple_string).to eql simpletxt
+    simple_hash = described_class.hash(simplettl)
+    puts "simple hash #{simple_hash}"
   end
 end


### PR DESCRIPTION
Because we get the predicates and then do a query for the objects, it makes sense to remove duplicate predicates.

With this change and fixes in my version for quoting literals and adding languages when available. [commit](https://github.com/whikloj/RdfHashing/commit/0300b114574cd8297ebe42669d9e29cfc68fd45e).

These both seem to have the same hash values for the doap test.

I am no Ruby programmer, so feel free to toss this PR and do it in a pretty way.